### PR TITLE
ansible lint verbose

### DIFF
--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -33,4 +33,4 @@ jobs:
       #       fb6e1071-bf0e-4131-be5d-b256010a2831 > PROXMOX_ANSIBLE_VAULT_PASSWORD
 
       - name: Run Ansible Lint
-        run: uv run ansible-lint inventory playbooks roles
+        run: uv run ansible-lint -v inventory playbooks roles


### PR DESCRIPTION
- **switch Ansible-internal PW from vault to generated**
- **small cleanup of acme playbook**
- **stop using ansible vault**
- **remove vault password from CI**
- **switch linting to verbose**
