### PR TITLE
fix exported PVE API token format

### DIFF
--- a/playbooks/tasks/proxmox-api-token-pve.yaml
+++ b/playbooks/tasks/proxmox-api-token-pve.yaml
@@ -23,7 +23,8 @@
       ansible.builtin.command:
         bws secret create
           {{ bws.output.token_name_prefix }}__{{ inventory_hostname_short_caps }}__{{ api_token.name | upper | replace('-', '_') }}
-          {{ api_token_object.value }} {{ bws.output.project_id }}
+          "{{ api_token.userid }}!{{ api_token.name }}={{ api_token_object.value }}"
+          {{ bws.output.project_id }}
       vars:
         api_token_object: '{{ create_token_result.stdout | from_json }}'
       delegate_to: localhost


### PR DESCRIPTION
User name and token name are required on top of the token value.